### PR TITLE
Fix for a lot of 'globals' data

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -10,10 +10,24 @@ function Sandbox(opts) {
 
 Sandbox.prototype.start = function() {
   var _this = this;
+  var data = '';
   
   this.server = net.createServer(function(c) {
-    c.on('data', function(data) {
-      _this.executeScript(c, data.toString());
+    c.on('data', function(chunk) {
+      var chunk = chunk.toString();
+      
+      if (chunk.charCodeAt(chunk.length - 1) !== 0) {
+        data += chunk;
+        // data is still incomplete
+        return;
+      } else {
+        // append all but the separator
+        data += chunk.substr(0, chunk.length - 1);
+      }
+      // execute the script with all data
+      _this.executeScript(c, data);
+      // reset data for the next data transfer
+      data = '';
     });
   });
 

--- a/lib/script.js
+++ b/lib/script.js
@@ -49,7 +49,7 @@ Script.prototype.createClient = function(globals) {
         source: _this.source,// the untrusted JS.
         sourceAPI: _this.sourceAPI,// the trusted API.
         globals: JSON.stringify(globals)// trusted global variables.
-      }));
+      }) + '\u0000'); // the chunk separator
     });
 
     client.on('close', function() {


### PR DESCRIPTION
### Bug description

When sending a lot of data (16KB?, 64KB? not sure) as globals the sandboxed script will fail, because it did not receive all of the data and tried to run the script on the incomplete data.
### Submitted bug fix

We use a separator character '\u0000' when sending the data to the sandbox to ensure that all data was received. So we accumulate all chunks until the separator is found and then execute the script with all data.
