### PR TITLE
Fixed typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Creating and Executing a Script
 ----------------------
 
 ```javascript
-var SandCastle = require('sandcastle').SandCastle,;
+var SandCastle = require('sandcastle').SandCastle;
 
 var sandcastle = new SandCastle();
 


### PR DESCRIPTION
`var SandCastle = require('sandcastle').SandCastle,;` becomes
`var SandCastle = require('sandcastle').SandCastle;`
