### PR TITLE
Feature: Memory limit for sand-box child process

### DIFF
--- a/lib/sandcastle.js
+++ b/lib/sandcastle.js
@@ -13,7 +13,8 @@ function SandCastle(opts) {
     timeout: 5000,
     sandbox: null,
     lastHeartbeat: (new Date()).getTime(),
-    socket: '/tmp/sandcastle.sock'
+    socket: '/tmp/sandcastle.sock',
+    memoryLimitMB: 0
   }, opts);
 
   if (this.api) this.sourceAPI = fs.readFileSync(this.api).toString();
@@ -51,7 +52,12 @@ SandCastle.prototype.spawnSandbox = function() {
   // attempt to unlink the old socket.
   try {fs.unlinkSync(this.socket)} catch (e) {};
 
-  this.sandbox = spawn(process.execPath, [__dirname + '/../bin/sandcastle.js', 'sandbox', '--socket=' + this.socket]);
+  this.sandbox = spawn(process.execPath, [ 
+    "--max_old_space_size=" + _this.memoryLimitMB.toString(),
+    __dirname + '/../bin/sandcastle.js',
+    'sandbox', 
+    '--socket=' + this.socket
+  ]);
 
   // Assume that the sandbox is created once
   // data is emitted on stdout.

--- a/test/sandcastle-test.js
+++ b/test/sandcastle-test.js
@@ -144,5 +144,30 @@ exports.tests = {
       finished();
     });
     script.run();
+  },
+  'enforce memory limit, when running scripts': function(finished, prefix) {    
+    var sandcastle = new SandCastle({memoryLimitMB: 10});
+
+    var script = sandcastle.createScript("\
+        exports.main = function() {\n\
+          var test = []; \
+          for(var i = 0; i < 5000000; ++i) { \
+            test[i] = 'a'; \
+          } \
+          exit(1); \
+        }\n\
+      "
+    );
+
+    script.on('exit', function(err, result) {
+      // Should not go here.
+      equal(false, true, prefix);
+    });
+
+    script.on('timeout', function(err, result) {
+      sandcastle.kill();
+      finished();
+    });
+    script.run();
   }
 }


### PR DESCRIPTION
Possibility to enforce memory limit on sandbox-child process. 

More information about the flag used:

What is the memory limit on a node process?
Currently, by default v8 has a memory limit of 512mb on 32-bit systems, and 1gb on 64-bit systems. The limit can be raised by setting --max-old-space-size to a maximum of ~1gb (32-bit) and ~1.7gb (64-bit), but it is recommended that you split your single process into several workers if you are hitting memory limits. [1]

[1] https://github.com/joyent/node/wiki/FAQ
