### PR TITLE
allow trusted api to access the globals

### DIFF
--- a/examples/contextObjectApi.js
+++ b/examples/contextObjectApi.js
@@ -1,0 +1,11 @@
+
+var StateManager = function(){
+	var state = contextObject.state;
+	delete contextObject.state;
+	this.getState=function(){
+		return state;
+	};
+};
+exports.api = {
+  stateManager : new StateManager()
+};

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -56,14 +56,6 @@ Sandbox.prototype.executeScript = function(connection, data) {
   try {
     var script = JSON.parse(data);
 
-    // The trusted API.
-    if (script.sourceAPI) {
-      var api = eval(script.sourceAPI);
-
-      Object.keys(api).forEach(function(key) {
-        contextObject[key] = api[key];
-      });
-    }
 
     // The trusted global variables.
     if (script.globals) {
@@ -71,6 +63,15 @@ Sandbox.prototype.executeScript = function(connection, data) {
 
       Object.keys(globals).forEach(function(key) {
         contextObject[key] = globals[key];
+      });
+    }
+
+    // The trusted API.
+    if (script.sourceAPI) {
+      var api = eval(script.sourceAPI);
+
+      Object.keys(api).forEach(function(key) {
+        contextObject[key] = api[key];
       });
     }
 

--- a/test/sandcastle-test.js
+++ b/test/sandcastle-test.js
@@ -231,4 +231,30 @@ describe('SandCastle', function () {
 
     script.run();
   });
+  it('should allow api to see globals',function(finished){
+     var sandcastle = new SandCastle({
+      api: './examples/contextObjectApi.js'
+    });
+     var script = sandcastle.createScript("\
+      exports.main = function() {\n\
+        var globalState = {};\n\
+        if(typeof state === \"undefined\"){\n\
+          globalState = 'none';\n\
+        }\n\
+        else{\n\
+          globalState = state;\n\
+        }\n\
+        exit({\n\
+          globalState:globalState,\n\
+          apiState:stateManager.getState()\n\
+        });\n\
+      }\n");
+     script.on('exit', function(err, result) {
+      equal(result.globalState, 'none');
+      equal(result.apiState.key, 'val');
+      sandcastle.kill();
+      finished();
+    });
+     script.run({state:{key:'val'}});
+  });
 });


### PR DESCRIPTION
In our usage of Sandcastle we want some context information available to the API methods we expose but not to the underlying scripts, by rearranging how sandbox populates globals vs api methods we can give api's access to the contextObject and allow it to make changes (so we can record the info we want and then delete it off the context object to hide it from the underlying user.

Added with example api and test.
