### PR TITLE
Windows Signals (no SIGHUP)

### DIFF
--- a/lib/sandcastle.js
+++ b/lib/sandcastle.js
@@ -5,7 +5,7 @@ var _ = require('underscore'),
   os = require('os'),
   spawn = require( 'child_process' ).spawn;
 
-var SIGHUP = os.platform()=='win32' ? 'SIGTERM : 'SIGHUP';
+var SIGHUP = os.platform()=='win32' ? 'SIGTERM' : 'SIGHUP';
 
 function SandCastle(opts) {
   var _this = this;


### PR DESCRIPTION
Windows doesn't support signals ('SIGHUP' causes error ENOSYS in Windows). As such, the child processes keep running. Now sending 'SIGTERM' under windows. From NodeJS documentation:

"Note that Windows does not support sending Signals, but node offers some emulation with process.kill(), and child_process.kill(): - Sending signal 0 can be used to search for the existence of a process - Sending SIGINT, SIGTERM, and SIGKILL cause the unconditional exit of the target process."
