### PR TITLE
Minor copy fixes, changed default behavior of refreshTimeoutOnTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ exports.api = {
   getState: function () {
     return _state;
   },
-  
+
   setState: function (state) {
     _state = state;
   }
@@ -317,9 +317,9 @@ script.run('main.getStates'); // { foo: true, bar: true, hello: true }
 Providing Tasks
 ------------------------
 
-In constrast to the [API](#providing-an-api) which runs trusted code __inside__ the sandbox the script can ask to do a specific task and get the result back.
+In contrast to the [API](#providing-an-api) which runs trusted code __inside__ the sandbox, the script can request that a task (a snippet of code) is executed in another process.
 
-To run a task call `runTask(taskName, options = {})` and provide a `onTask(taskName, data)` method within the script file. Alternatively you can create a task specific function `on{TaskName}Task` to receive data for an individual task.
+To run a task call `runTask(taskName, options = {})` and provide a `onTask(taskName, data)` method within the script file. Alternatively you can create a task specific function `on{TaskName}Task`, to receive data for an individual task.
 
 ```javascript
 var script = sandcastle.createScript("\
@@ -344,7 +344,7 @@ script.on('task', function (err, taskName, options, methodName, callback) {
 });
 ```
 
-By default the timeout gets refreshed every time a answer will be send to the script but you can fallback to the old behaviour by setting the `refreshTimeoutOnTask` option to `false`.
+`refreshTimeoutOnTask` can be used to control the timeout behavior of the script executing the task. If set to true, the script will have its timeout reset when the task is completed.
 
 Contributing
 ---------

--- a/lib/sandcastle.js
+++ b/lib/sandcastle.js
@@ -18,7 +18,7 @@ function SandCastle(opts) {
     memoryLimitMB: 0,
     cwd: process.cwd(),
     spawnExecPath: process.execPath,
-    refreshTimeoutOnTask: true
+    refreshTimeoutOnTask: false
   }, opts);
 
   if (this.api) {

--- a/lib/script.js
+++ b/lib/script.js
@@ -152,9 +152,7 @@ Script.prototype.onTask = function(client, methodName, data) {
   parsed.output.options = parsed.output.options || {};
 
   this.emit('task', parsed.error, parsed.output.task, parsed.output.options, methodName, function (answerData) {
-    if (_this.refreshTimeoutOnTask) {
-        _this.createTimeout(methodName); // received an answer to the task - reseting the timeout
-      }
+    if (_this.refreshTimeoutOnTask) _this.createTimeout(methodName);
     client.write(JSON.stringify({ task: parsed.output.task, data: answerData }) + '\u0000');
   });
 

--- a/test/sandcastle-test.js
+++ b/test/sandcastle-test.js
@@ -236,7 +236,7 @@ describe('SandCastle', function () {
     var sandcastle = new SandCastle({
       api: './examples/contextObjectApi.js'
     });
- 
+
     var script = sandcastle.createScript("\
      exports.main = function() {\n\
        var globalState = {};\n\
@@ -251,7 +251,7 @@ describe('SandCastle', function () {
          apiState:stateManager.getState()\n\
        });\n\
      }\n");
- 
+
     script.on('exit', function(err, result) {
        equal(result.globalState, 'none');
        equal(result.apiState.key, 'val');
@@ -283,7 +283,7 @@ describe('SandCastle', function () {
 
     script.on('task', function (err, taskName, options, methodName, callback) {
         options.count++;
-        
+
         equal(taskName, 'test');
         equal(methodName, 'main');
 


### PR DESCRIPTION
- I defaulted refreshTimeoutOnTask to `false` I think this is a better default (otherwise the default settings create a sandbox vulnerable to scripts which never time out).
- I made a few minor copy edits.
