### PR TITLE
Pass globals on re-run

### DIFF
--- a/lib/script.js
+++ b/lib/script.js
@@ -74,14 +74,14 @@ Script.prototype.createClient = function(methodName, globals) {
     client.on('close', function() {
       if (!_this.dataReceived) {
         setTimeout(function() {
-          _this.createClient(methodName);
+          _this.createClient(methodName, globals);
         }, 500);
       }
     });
 
     client.on('error', function(err) {
       setTimeout(function() {
-        _this.createClient(methodName);
+        _this.createClient(methodName, globals);
       }, 500);
     });
 


### PR DESCRIPTION
Without this, you end up with nasty race conditions when you're using globals and the sandcastle gets kicked over. E.g.:
1. Pass `while(true){}` to sandcastle
2. Before that script is finished, pass `exit(some_globals_variable)` to sandcastle
3. Sandcastle gets kicked over because the `while(true){}` timed out
4. The new sandcastle runs `exit(some_globals_variable)`, but now it has no `globals` so the script crashes
