### PR TITLE
Add debug to sandcastle

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ script.on('task', function (err, taskName, options, methodName, callback) {
 
 `refreshTimeoutOnTask` can be used to control the timeout behavior of the script executing the task. If set to true, the script will have its timeout reset when the task is completed.
 
+Debugging
+---------
+Make debugging a little easier by ensuring the DEBUG environment variable includes `sandcastle`.
+
 Contributing
 ---------
 

--- a/lib/sandcastle.js
+++ b/lib/sandcastle.js
@@ -3,6 +3,7 @@ var _ = require('lodash'),
   path = require('path'),
   fs = require('fs'),
   os = require('os'),
+  debug = require('debug')('sandcastle'),
   spawn = require( 'child_process' ).spawn;
 
 var SIGHUP = os.platform()=='win32' ? 'SIGTERM' : 'SIGHUP';
@@ -82,11 +83,13 @@ SandCastle.prototype.spawnSandbox = function() {
   // Assume that the sandbox is created once
   // data is emitted on stdout.
   this.sandbox.stdout.on('data', function(data) {
+    debug("Sandbox output: " + data.toString());
     _this.waitingOnHeartbeat = false; // Used to keep only one heartbeat on the wire at a time.
     _this.sandboxInitialized = true;
   });
 
   this.sandbox.stderr.on('data', function(data) {
+    debug("Sandbox error: " + data.toString());
     _this.waitingOnHeartbeat = false;
   });
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "bufferstream": "^0.6.2",
     "clone": "^0.1.18",
+    "debug": "^2.1.2",
     "lodash": "^2.4.1",
     "optimist": "^0.3.4"
   },


### PR DESCRIPTION
I started using sandcastle in a personal project and I had a pretty tough debugging why some tasks were timing out. Adding a debug statement made it quite a bit easier as I could see what errors were be thrown by the api supplied. 