### PR TITLE
Add windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@ test.sh
 test.js
 nohup.out
 out.txt
+.idea
+*.iml
 
 /coverage.html

--- a/bin/sandcastle.js
+++ b/bin/sandcastle.js
@@ -7,7 +7,7 @@ var sandcastle = require('../lib'),
 switch (mode) {
   case 'sandbox':
     (new sandcastle.Sandbox({
-        socket: (argv.socket || '/tmp/sandcastle.sock')
+        socket: (argv.socket || socketName())
     })).start();
     break;
   default:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 exports.Pool = require('./pool').Pool;
 exports.SandCastle = require('./sandcastle').SandCastle;
 exports.Sandbox = require('./sandbox').Sandbox;
+exports.socketName = require('./socketname').socketName;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -1,5 +1,6 @@
 var _ = require('lodash'),
-  SandCastle = require("./sandcastle").SandCastle;
+  SandCastle = require("./sandcastle").SandCastle,
+  socketName = require("./socketname").socketName;
 
 function Pool(opts, sandCastleCreationOpts) {
   _.extend(this, {
@@ -18,7 +19,7 @@ function Pool(opts, sandCastleCreationOpts) {
     var sandCastleOptions = {}
     _.extend( sandCastleOptions,
               sandCastleCreationOpts,
-              { socket: '/tmp/sandcastle_' + i.toString() + '.sock' }
+              { socket: socketName(i) }
             );
 
     this.sandcastles.push({

--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -2,11 +2,12 @@ var _ = require('lodash'),
   net = require('net'),
   vm = require('vm'),
   BufferStream = require('bufferstream'),
-  clone = require('clone');
+  clone = require('clone'),
+  socketName = require("./socketname").socketName;
 
 function Sandbox(opts) {
   _.extend(this, {
-    socket: '/tmp/sandcastle.sock'
+    socket: socketName()
   }, opts);
 }
 

--- a/lib/sandcastle.js
+++ b/lib/sandcastle.js
@@ -4,7 +4,8 @@ var _ = require('lodash'),
   fs = require('fs'),
   os = require('os'),
   debug = require('debug')('sandcastle'),
-  spawn = require( 'child_process' ).spawn;
+  spawn = require( 'child_process' ).spawn,
+  socketName = require("./socketname").socketName;
 
 var SIGHUP = os.platform()=='win32' ? 'SIGTERM' : 'SIGHUP';
 
@@ -17,7 +18,7 @@ function SandCastle(opts) {
     timeout: 5000,
     sandbox: null,
     lastHeartbeat: (new Date()).getTime(),
-    socket: '/tmp/sandcastle.sock',
+    socket: socketName(),
     useStrictMode: true,
     memoryLimitMB: 0,
     cwd: process.cwd(),

--- a/lib/script.js
+++ b/lib/script.js
@@ -3,14 +3,15 @@ var _ = require('lodash'),
   events = require('events'),
   util = require('util'),
   BufferStream = require('bufferstream'),
-  Buffer = require('buffer').Buffer;
+  Buffer = require('buffer').Buffer,
+  socketName = require("./socketname").socketName;
 
 function Script(opts) {
   events.EventEmitter.call(this);
   
   _.extend(this, {
     source: '',
-    socket: '/tmp/sandcastle.sock',
+    socket: socketName(),
     timeout: 5000,
     exited: false,
     sandcastle: null // the parent sandcastle executing this script.

--- a/lib/socketname.js
+++ b/lib/socketname.js
@@ -1,0 +1,13 @@
+var os = require('os');
+
+function unixSocketName(instanceNumber) {
+  var instanceString = typeof instanceNumber === 'number' ? '_' + instanceNumber : '';
+  return '/tmp/sandcastle' + instanceString + '.sock';
+}
+
+function windowsSocketName(instanceNumber) {
+  var instanceString = typeof instanceNumber === 'number' ? '_' + instanceNumber : '';
+  return '\\\\.\\pipe\\sandcastle' + instanceString;
+}
+
+exports.socketName = os.platform() === 'win32' ? windowsSocketName : unixSocketName

--- a/test/sandcastle-test.js
+++ b/test/sandcastle-test.js
@@ -255,7 +255,7 @@ describe('SandCastle', function () {
   });
 
   it('sets cwd, when running scripts', function(finished) {
-    var cwd = process.cwd() + '/test';
+    var cwd = process.cwd() + path.sep + 'test';
 
     var sandcastle = new SandCastle({
       api: '../examples/api.js',


### PR DESCRIPTION
Use function socketName instead of hard coding socket names. The socketName
function returns names of the form /tmp/sandcastle_x.sock on Unix/MacOS and
names of the form \.\pipe\sandcastle_x on Windows. x is the instance number
(if no instance number is given the entire _x section is omitted).

Minor fix to one test to use path.sep instead of hardcoded / for file
separator.

Added exclusions for IntelliJ/WebStorm project files in .gitignore
